### PR TITLE
chore: fix regex validation to enforce exact match (public or private)

### DIFF
--- a/solutions/secure/variables.tf
+++ b/solutions/secure/variables.tf
@@ -143,7 +143,7 @@ variable "kms_endpoint_type" {
   description = "The type of endpoint to be used for communicating with the KMS instance. Allowed values are: 'public' or 'private' (default)"
   default     = "private"
   validation {
-    condition     = can(regex("public|private", var.kms_endpoint_type))
+    condition     = can(regex("^(public|private)$", var.kms_endpoint_type))
     error_message = "The kms_endpoint_type value must be 'public' or 'private'."
   }
 }


### PR DESCRIPTION
https://github.ibm.com/GoldenEye/issues/issues/15651
Fix regex validation to enforce exact match (public or private)